### PR TITLE
Batch of QoL tweaks (changing ascii, randomizing state on (re)load, blkw, etc.)

### DIFF
--- a/src/backend/assembler.cpp
+++ b/src/backend/assembler.cpp
@@ -7,6 +7,7 @@
 #include <fstream>
 #include <sstream>
 #include <vector>
+#include <random>
 
 #include "aliases.h"
 #include "asm_types.h"
@@ -494,10 +495,13 @@ std::pair<bool, std::vector<lc3::core::MemLocation>> lc3::core::Assembler::build
                         msg << utils::ssprintf("0x%0.4x", value);
                     } else if(encoder.isValidPseudoBlock(statement)) {
                         uint32_t size = encoder.getPseudoBlockSize(statement);
+                        std::random_device rd;
+                        std::uniform_int_distribution<> distr(0, 0xFFFF); 
+                        // .blkw should technically skip memory locations, but we'll fill with random data to mock that
                         for(uint32_t i = 0; i < size; i += 1) {
-                            ret.emplace_back(0, statement.line, false);
+                            ret.emplace_back(distr(rd), statement.line, false);
                         }
-                        msg << utils::ssprintf("mem[0x%0.4x:0x%04x] = 0", statement.pc, statement.pc + size - 1);
+                        msg << utils::ssprintf("mem[0x%0.4x:0x%04x] skipped for .blkw", statement.pc, statement.pc + size - 1);
                     } else if(encoder.isValidPseudoString(statement)) {
                         std::string const & value = encoder.getPseudoString(statement);
                         for(char c : value) {

--- a/src/gui/local_modules/lc3interface/wrapper.cpp
+++ b/src/gui/local_modules/lc3interface/wrapper.cpp
@@ -161,6 +161,7 @@ NAN_METHOD(LoadObjectFile)
     std::string filename((char const *) *str);
 
     try {
+        sim->randomizeState(); // lc3 should have random data on memory when loading object files
         sim->loadObjFile(filename);
     } catch(std::exception const & e) {
         Nan::ThrowError(e.what());

--- a/src/gui/src/renderer/components/editor/Editor.vue
+++ b/src/gui/src/renderer/components/editor/Editor.vue
@@ -193,6 +193,7 @@ export default {
       require("brace/mode/less");
       require("brace/theme/textmate");
       require("brace/theme/twilight");
+      require("brace/ext/searchbox")
       editor.setShowPrintMargin(false);
       editor.setOptions({
         fontSize: "1.25em"

--- a/src/gui/src/renderer/components/simulator/Simulator.vue
+++ b/src/gui/src/renderer/components/simulator/Simulator.vue
@@ -369,8 +369,7 @@ export default {
       this.loadedSnackBar = true;
       // clear output on file (re)load
       if (this.$store.getters.clear_out_on_reload) {
-        this.console_str = "";
-        lc3.ClearOutput();
+        this.clearConsole();
       }
     },
     reloadFiles() {
@@ -411,10 +410,12 @@ export default {
     },
     reinitializeMachine() {
       lc3.ReinitializeMachine();
+      this.clearConsole();
       this.updateUI();
     },
     randomizeMachine() {
       lc3.RandomizeMachine();
+      this.clearConsole();
       this.updateUI();
     },
     endSimulation(jump_to_pc) {

--- a/src/gui/src/renderer/components/simulator/Simulator.vue
+++ b/src/gui/src/renderer/components/simulator/Simulator.vue
@@ -554,7 +554,7 @@ export default {
     jumpToMemViewStr() {
       if (this.jmp_to_loc_field[0] === 'x') {
         this.jmp_to_loc_field = '0' + this.jmp_to_loc_field
-      } else if (this.jmp_to_loc_field[0].slice(0,2) !== '0x') {
+      } else if (this.jmp_to_loc_field.slice(0,2) !== '0x') {
         this.jmp_to_loc_field = '0x' + this.jmp_to_loc_field
       }
       this.jumpToMemView(this.parseValueString(this.jmp_to_loc_field));

--- a/src/gui/src/renderer/components/simulator/Simulator.vue
+++ b/src/gui/src/renderer/components/simulator/Simulator.vue
@@ -203,6 +203,9 @@
                         </v-edit-dialog>
                       </div>
                       <div class="data-cell">
+                        <i>{{ props.item.ascii }}</i>
+                      </div>
+                      <div class="data-cell">
                         <i>{{ props.item.line }}</i>
                       </div>
                     </tr>
@@ -212,7 +215,7 @@
 
               <div id="controls">
                 <div id="jump-to-location">
-                  <v-text-field single-line label="Jump To Location" @change="jumpToMemViewStr"></v-text-field>
+                  <v-text-field single-line label="Jump To Location" @change="jumpToMemViewStr" v-model="jmp_to_loc_field"></v-text-field>
                 </div>
                 <div id="jump-buttons">
                   <v-tooltip top>
@@ -312,6 +315,7 @@ export default {
         }
       },
       loadedSnackBar: false,
+      jmp_to_loc_field: ''
     };
   },
   components: {
@@ -486,9 +490,13 @@ export default {
       // Memory
       for(let i = 0; i < this.mem_view.data.length; i++) {
         let addr = (this.mem_view.start + i) & 0xffff;
+        let mem_val = lc3.GetMemValue(addr);
         this.mem_view.data[i].addr = addr;
-        this.mem_view.data[i].value = lc3.GetMemValue(addr);
+        this.mem_view.data[i].value = mem_val;
         this.mem_view.data[i].line = lc3.GetMemLine(addr);
+        this.mem_view.data[i].ascii = mem_val <= 127
+            ? String.fromCharCode(mem_val) 
+            : '';
       }
 
       this.updateConsole();
@@ -543,8 +551,13 @@ export default {
       this.mem_view.start = new_start & 0xffff;
       this.updateUI();
     },
-    jumpToMemViewStr(value) {
-      this.jumpToMemView(this.parseValueString(value));
+    jumpToMemViewStr() {
+      if (this.jmp_to_loc_field[0] === 'x') {
+        this.jmp_to_loc_field = '0' + this.jmp_to_loc_field
+      } else if (this.jmp_to_loc_field[0].slice(0,2) !== '0x') {
+        this.jmp_to_loc_field = '0x' + this.jmp_to_loc_field
+      }
+      this.jumpToMemView(this.parseValueString(this.jmp_to_loc_field));
     },
     jumpToPrevMemView() {
       let new_start = this.mem_view.start - this.mem_view.data.length;
@@ -600,7 +613,7 @@ export default {
       }
       return dec
     },
-    parseValueString : (value) => {
+    parseValueString(value) {
       let mod_value = value;
       if(mod_value[0] == 'x') {
         mod_value = '0' + mod_value;
@@ -759,7 +772,7 @@ export default {
 
 .mem-row {
   display: grid;
-  grid-template-columns: 2em 2em 1fr 1fr 1fr 4fr;
+  grid-template-columns: 2em 2em 1fr 1fr 1fr 1fr 4fr;
   align-items: center;
 }
 


### PR DESCRIPTION
This PR fixes the following problems:
- ASCII characters that are changed after program execution can be observed separately from .stringz instructions (via a new column)
![Screenshot 2023-10-14 at 11 49 55 AM](https://github.com/gt-cs2110/lc3tools/assets/49962416/b419d2bd-721f-4aa6-bc9f-c637cd388c22)
- Memory state is now always randomized on every object file load (like complx)
	-	This fixes the problem where remnants of past versions of a program are left in the simulator view
- .blkw now "skips" over memory locations instead of overwriting existing items with zeros
	-	This is actually mocked by writing random values in the spots that the .blkw instruction declares; by how the assembler/loader is designed, we can't skip portions of memory when writing a program into it. 
- 'Ctrl/Cmd-F' now works on the editor
- "Jump to Location" box now defaults to interpreting the field as hex instead of decimal values

Let me know if there are bugs, or anything else we should take care of before we merge and start building for students to use.
