### PR TITLE
fixing path in windows build of gui

### DIFF
--- a/src/gui/local_modules/lc3interface/binding.gyp
+++ b/src/gui/local_modules/lc3interface/binding.gyp
@@ -27,7 +27,7 @@
                         }
                     },
                     'link_settings': {
-                        'libraries': ['<(module_root_dir)/../../../../build/lib/Release/lc3core']
+                        'libraries': ['<(module_root_dir)/../../../../build/Release/lib/lc3core']
                     }
                 }]
             ]


### PR DESCRIPTION
Cmake puts the lib in a different location than yarn expects it because someone is very good at testing the changes they make to software they release for all textbook users