### PR TITLE
Remove exponential-time Levenshtein from assembler

### DIFF
--- a/src/backend/encoder.h
+++ b/src/backend/encoder.h
@@ -23,6 +23,7 @@ namespace asmbl
 
         bool isStringPseudo(std::string const & search) const;
         bool isStringValidReg(std::string const & search) const;
+        bool isStringInstructionName(std::string const & name) const;
         bool isPseudo(Statement const & statement) const;
         bool isInst(Statement const & statement) const;
         bool isValidPseudoOrig(Statement const & statement, bool log_enable = false) const;
@@ -32,8 +33,6 @@ namespace asmbl
         bool isValidPseudoBlock(Statement const & statement, bool log_enable = false) const;
         bool isValidPseudoString(Statement const & statement, bool log_enable = false) const;
         bool isValidPseudoEnd(Statement const & statement, bool log_enable = false) const;
-
-        uint32_t getDistanceToNearestInstructionName(std::string const & search) const;
 
         bool validatePseudo(Statement const & statement, SymbolTable const & symbols) const;
         optional<PIInstruction> validateInstruction(Statement const & statement) const;
@@ -56,9 +55,6 @@ namespace asmbl
             std::vector<StatementPiece::Type> const & valid_types, uint32_t operand_count, bool log_enable) const;
 
         std::map<std::string, std::vector<PIInstruction>> instructions_by_name;
-
-        uint32_t levDistance(std::string const & a, std::string const & b) const;
-        uint32_t levDistanceHelper(std::string const & a, uint32_t a_len, std::string const & b, uint32_t b_len) const;
     };
 };
 };


### PR DESCRIPTION
Chirag's Levenshtein distance computation is implemented in exponential time and is used extremely frequently in the assembler. This was causing me massive performance problems for large programs, like assembly times on the order of minutes. Thankfully our fork's master is a little better for some reason (only seconds instead of minutes).

I have a rogues' gallery of 62 LC-3 assembly files, and here are the empirical results from this change:

           Mean         Median   Max     Min
    Before 0.23275806   0.003    13.591  0.001
    After  0.00127419   0.001    0.008   0.001

So on average, I observed a ~180x speedup, but for particularly big files (the "max" there is a ~1700-line assembly file), speedup can be as high as ~1600x: 13.6s to 8ms. As a more realistic example, for the wordProcessor.asm TA solution from Fall 2023, the speedup is ~100x: from 450ms to 4ms.

What is the cost? Not much, in my opinion. One might hesitate to remove the fuzzy matching in `encoder.cpp`, but actually, those fuzzy suggestions are logged at the level P_NOTE, which is a notch lower than the default (production build) loglevel of P_WARNING. So students never saw these suggestions in the first place. I certainly never did.

What about the Levenshtein distance usage in `assembler.cpp`? To be blunt, I fundamentally disagree with its usage there. Yes, the grammar for LC-3 assembly is ambiguous — for example, in `putc putc`, is the first word a label or an instruction?(†) However, you cannot "fix" an ambiguous grammar with heuristic tricks as Chirag attempts here. Ideally, you fix the grammar itself, but we are in a C++-like legacy situation here, so the best situation is to pick a simple rule and stick with it. That's what I changed the code to do. I am skeptical that the existing complicated heuristic logic benefits students with typos at all, or at least I do not think its possible utility earns its ~100x runtime overhead.

If compilers should not use exponential time algorithms, assemblers _definitely_ should not.

------

(†) Simply requiring a colon `:` after label definitions would resolve this ambiguity, as well as making code easier for students to read. Alas, that would require modifying nearly every textbook example, which is probably unappealing to the authors.