### PR TITLE
Simulate JSRR R7 according to ISA

### DIFF
--- a/src/backend/isa_impl.cpp
+++ b/src/backend/isa_impl.cpp
@@ -154,15 +154,17 @@ PIMicroOp JSRRInstruction::buildMicroOps(MachineState const & state) const
 {
     (void) state;
 
-    PIMicroOp link = std::make_shared<RegWritePCMicroOp>(7);
-    PIMicroOp jump = std::make_shared<PCWriteRegMicroOp>(getOperand(3)->getValue());
+    PIMicroOp temp = std::make_shared<RegWritePCMicroOp>(8); // TEMP=PC*
+    PIMicroOp jump = std::make_shared<PCWriteRegMicroOp>(getOperand(3)->getValue()); // PC=BaseR
+    PIMicroOp link = std::make_shared<RegAddImmMicroOp>(7, 8, 0); // R7=TEMP
     PIMicroOp callback = std::make_shared<CallbackMicroOp>(CallbackType::SUB_ENTER);
     PIMicroOp func_trace = std::make_shared<PushFuncTypeMicroOp>(FuncType::SUBROUTINE);
 
-    link->insert(jump);
-    jump->insert(callback);
+    temp->insert(jump);
+    jump->insert(link);
+    link->insert(callback);
     callback->insert(func_trace);
-    return link;
+    return temp;
 }
 
 PIMicroOp LDInstruction::buildMicroOps(MachineState const & state) const


### PR DESCRIPTION
Currently, the behavior of `JSRR R7` in LC3Tools does not match Appendix A of the textbook. It performs the pseudocode:

    R7=PC*
    PC=BaseR

But the LC-3 ISA in the textbook (Appendix A, page 662) actually specifies the following:

    TEMP=PC*
    PC=BaseR
    R7=TEMP

The behavior is the same _except_ when BaseR=R7. So this commit makes LC3Tools match the textbook. (Otherwise, the behavior is confusing. I hit this in the wild and got very confused.)