### PR TITLE
Fix failing builds on Ubuntu 23.10

### DIFF
--- a/src/backend/converter.cpp
+++ b/src/backend/converter.cpp
@@ -7,6 +7,7 @@
 #include <string>
 #include <sstream>
 #include <vector>
+#include <stdint.h>
 
 #ifdef _ENABLE_DEBUG
     #include <chrono>

--- a/src/backend/mem.cpp
+++ b/src/backend/mem.cpp
@@ -2,6 +2,7 @@
  * Copyright 2020 McGraw-Hill Education. All rights reserved. No reproduction or distribution without the prior written consent of McGraw-Hill Education.
  */
 #include <cstring>
+#include <stdint.h>
 
 #include "mem.h"
 

--- a/src/common/common.cpp
+++ b/src/common/common.cpp
@@ -2,6 +2,7 @@
  * Copyright 2020 McGraw-Hill Education. All rights reserved. No reproduction or distribution without the prior written consent of McGraw-Hill Education.
  */
 #include <cstring>
+#include <stdint.h>
 
 #include "common.h"
 


### PR DESCRIPTION
Fixes #10. Confirmed won't break or change anything else in lc3tools.