### PR TITLE
fix verify overloads with template types

### DIFF
--- a/src/test/framework2110.cpp
+++ b/src/test/framework2110.cpp
@@ -255,26 +255,6 @@ void Tester::testSingle(TestCase const &test) {
   this->simulator = nullptr;
 }
 
-template <typename T>
-void Tester::verify(std::string const &label, T out, T expected,
-                    bool (*comp)(T, T), std::string (*print)(T)) {
-  std::ostringstream message;
-  message << "Expected: " << print(expected) << ", Got: " << print(out)
-          << std::endl;
-  appendTestPart(label, message, comp(out, expected));
-}
-
-template <typename T>
-void Tester::verify(std::string const &label, T out, T expected) {
-  std::ostringstream message;
-  message << "Expected: " << expected << ", Got: " << out << std::endl;
-  appendTestPart(label, message, out == expected);
-}
-
-void Tester::verify(std::string const &label, bool pass) {
-  appendTestPart(label, "", pass);
-}
-
 void Tester::appendTestPart(std::string const &label,
                             std::string const &message, bool pass) {
   TestPart *test_part = new TestPart{};

--- a/src/test/framework2110.h
+++ b/src/test/framework2110.h
@@ -93,11 +93,22 @@ public:
 
   template <typename T>
   void verify(std::string const &label, T out, T expected, bool (*comp)(T, T),
-              std::string (*print)(T));
+              std::string (*print)(T)) {
+    std::ostringstream message;
+    message << "Expected: " << print(expected) << ", Got: " << print(out)
+            << std::endl;
+    appendTestPart(label, message.str(), comp(out, expected));
+  };
   template <typename T>
-  void verify(std::string const &label, T out, T expected);
+  void verify(std::string const &label, T out, T expected) {
+    std::ostringstream message;
+    message << "Expected: " << expected << ", Got: " << out << std::endl;
+    appendTestPart(label, message.str(), out == expected);
+  };
 
-  void verify(std::string const &label, bool pass);
+  void verify(std::string const &label, bool pass) {
+    appendTestPart(label, "", pass);
+  };
 
   void output(std::string const &message);
   void debugOutput(std::string const &message);


### PR DESCRIPTION
test files using verify overloads weren't compiling, turns out template functions must be defined in the header ‼️ 