### PR TITLE
Allow for written tests to specify machine randomization seed

### DIFF
--- a/docs/API2110.md
+++ b/docs/API2110.md
@@ -3,25 +3,25 @@
 
 # Table of Contents
 
-- [Running the Machine](API.md#running-the-machine)
-- [Getting/Setting Machine State](API.md#gettingsetting-machine-state)
-- [Callbacks](API.md#callbacks)
-- [Miscellaneous](API.md#miscellaneous)
-- [Test Cases](API.md#test-cases)
-- [Memory Interface with Labels](API.md#memory-interface-with-labels)
-- [String Reading in Memory](API.md#string-reading-in-memory)
-- [Automated Input](API.md#automated-input)
-- [String Manipulation and Comparison](API.md#string-manipulation-and-comparison)
+- [Running the Machine](API2110.md#running-the-machine)
+- [Getting/Setting Machine State](API2110.md#gettingsetting-machine-state)
+- [Callbacks](API2110.md#callbacks)
+- [Miscellaneous](API2110.md#miscellaneous)
+- [Test Cases](API2110.md#test-cases)
+- [Memory Interface with Labels](API2110.md#memory-interface-with-labels)
+- [String Reading in Memory](API2110.md#string-reading-in-memory)
+- [Automated Input](API2110.md#automated-input)
+- [String Manipulation and Comparison](API2110.md#string-manipulation-and-comparison)
 
 # Testing Framework API
 
 The purpose of this document is to describe the subset of the LC3Tools API that
 is relevant to unit testing. The full API can be found in
 `src/backend/interface.h`. It is highly recommended to read the [testing
-framework document](TEST.md) before reading this document.
+framework document](TEST2110.md) before reading this document.
 
-There are two main types to use to the API: [`lc3::sim`](API.md#lc3sim),
-and [`Tester`](API.md#tester).
+There are two main types to use to the API: [`lc3::sim`](API2110.md#lc3sim),
+and [`Tester`](API2110.md#tester).
 
 # `lc3::sim`
 
@@ -55,7 +55,7 @@ Return Value:
 
 Run the machine from the location of the PC until any keyboard input is
 requested. This is useful when verifying I/O. See the [I/O
-Paradigm (Polling)](TEST.md#io-paradigm-polling) for more details on usage.
+Paradigm (Polling)](TEST2110.md#io-paradigm-polling) for more details on usage.
 
 Return Value:
 
@@ -279,7 +279,7 @@ Arguments:
 - `sim`: Interface to simulator.
 - `tester`: Interface to testing framework.
 
-### `void registerTest(std::string const & name, test_func_t test_func, bool randomize)`
+### `void registerTest(std::string const & name, test_func_t test_func, int randomizeSeed)`
 
 Register a test case with the testing framework.
 
@@ -287,8 +287,10 @@ Arguments:
 
 - `name`: Name of test case.
 - `test_func`: Function to call when invoking test case.
-- `randomize`: `true` if machine should be randomized before running test case,
-  `false` otherwise.
+- `randomizeSeed`: seed to use for randomizing the machine before program
+  execution. Set to `0` for this seed to also be random. Set to `-1` to disable
+  randomization. Note that the `seed` CLI flag from the test executable will
+  override this argument.
 
 ### `void verify(std::string const & label, bool pred)`
 
@@ -566,4 +568,3 @@ Return Value:
 Copyright 2020 &copy; McGraw-Hill Education. All rights reserved. No
 reproduction or distribution without the prior written consent of McGraw-Hill
 Education.
-

--- a/src/test/framework2110.cpp
+++ b/src/test/framework2110.cpp
@@ -167,8 +167,8 @@ int main(int argc, char *argv[]) {
 }
 
 TestCase::TestCase(std::string const &name, test_func_t test_func,
-                   bool randomize)
-    : name(name), test_func(test_func), randomize(randomize) {}
+                   int randomizeSeed)
+    : name(name), test_func(test_func), randomizeSeed(randomizeSeed) {}
 
 Tester::Tester(bool print_output, uint32_t print_level, bool ignore_privilege,
                bool verbose, uint64_t seed,
@@ -178,8 +178,8 @@ Tester::Tester(bool print_output, uint32_t print_level, bool ignore_privilege,
       obj_filenames(obj_filenames) {}
 
 void Tester::registerTest(std::string const &name, test_func_t test_func,
-                          bool randomize) {
-  tests.emplace_back(name, test_func, randomize);
+                          int randomizeSeed) {
+  tests.emplace_back(name, test_func, randomizeSeed);
 }
 
 void Tester::testAll(void) {
@@ -212,14 +212,16 @@ void Tester::testSingle(TestCase const &test) {
 
   curr_test_result.test_name = test.name;
 
-  if (test.randomize) {
+  // seed cli arg >> test.randomizeSeed
+  if (test.randomizeSeed >= 0) {
     if (seed == 0) {
-      seed = simulator.randomizeState();
+      seed = simulator.randomizeState(test.randomizeSeed);
     } else {
       simulator.randomizeState(seed);
     }
     curr_test_result.seed = seed;
   } else {
+    // if test.randomizeSeed is negative, don't randomize
     curr_test_result.seed = -1;
   }
 

--- a/src/test/framework2110.cpp
+++ b/src/test/framework2110.cpp
@@ -255,26 +255,6 @@ void Tester::testSingle(TestCase const &test) {
   this->simulator = nullptr;
 }
 
-template <typename T>
-void Tester::verify(std::string const &label, T out, T expected,
-                    bool (*comp)(T, T), std::string (*print)(T)) {
-  std::ostringstream message;
-  message << "Expected: " << print(expected) << ", Got: " << print(out)
-          << std::endl;
-  appendTestPart(label, message, comp(out, expected));
-}
-
-template <typename T>
-void Tester::verify(std::string const &label, T out, T expected) {
-  std::ostringstream message;
-  message << "Expected: " << expected << ", Got: " << out << std::endl;
-  appendTestPart(label, message, out == expected);
-}
-
-void Tester::verify(std::string const &label, bool pass) {
-  appendTestPart(label, "", pass);
-}
-
 void Tester::appendTestPart(std::string const &label,
                             std::string const &message, bool pass) {
   TestPart *test_part = new TestPart{};

--- a/src/test/framework2110.cpp
+++ b/src/test/framework2110.cpp
@@ -324,7 +324,7 @@ void Tester::printJson() {
     // so that no points will be awarded
     if (test_result.error) {
       json e = {
-          {"label", test_result.error->label},
+          {"displayName", test_result.error->label},
           {"message", test_result.error->message},
       };
       partial_fails.push_back(e);
@@ -347,7 +347,7 @@ void Tester::printJson() {
           continue;
         auto part = parts.at(i);
         json part_json = {
-            {"label", part->label},
+            {"displayName", part->label},
             {"message", part->message},
         };
         partial_fails.push_back(part_json);

--- a/src/test/framework2110.h
+++ b/src/test/framework2110.h
@@ -24,9 +24,9 @@ extern std::function<void(lc3::sim &)> testTeardown;
 struct TestCase {
   std::string name;
   test_func_t test_func;
-  bool randomize;
+  int randomizeSeed;
 
-  TestCase(std::string const &name, test_func_t test_func, bool randomize);
+  TestCase(std::string const &name, test_func_t test_func, int randomizeSeed);
 };
 
 struct TestPart {
@@ -89,7 +89,7 @@ public:
          std::vector<std::string> const &obj_filenames);
 
   void registerTest(std::string const &name, test_func_t test_func,
-                    bool randomize);
+                    int randomizeSeed);
 
   template <typename T>
   void verify(std::string const &label, T out, T expected, bool (*comp)(T, T),

--- a/src/test/framework2110.h
+++ b/src/test/framework2110.h
@@ -93,11 +93,22 @@ public:
 
   template <typename T>
   void verify(std::string const &label, T out, T expected, bool (*comp)(T, T),
-              std::string (*print)(T));
+              std::string (*print)(T)) {
+    std::ostringstream message;
+    message << "Expected: " << print(expected) << ", Got: " << print(out)
+            << std::endl;
+    appendTestPart(label, message.str(), comp(out, expected));
+  };
   template <typename T>
-  void verify(std::string const &label, T out, T expected);
+  void verify(std::string const &label, T out, T expected) {
+    std::ostringstream message;
+    message << "Expected: " << expected << ", Got: " << out << std::endl;
+    appendTestPart(label, message.str(), out == expected);
+  };
 
-  void verify(std::string const &label, bool pass);
+  void verify(std::string const &label, bool pass) {
+    appendTestPart(label, "", pass);
+  };
 
   void output(std::string const &message);
   void debugOutput(std::string const &message);


### PR DESCRIPTION
Allows for us to enforce randomization on the state of the lc3 without it being "truly" (pseudo)random, while also not having to change zucchini once more. 

An actual justification is that this allows us to write better tests in scenarios where randomization could make a difference (e.g. checking for proper string termination). Local testing is much less error-prone than having to remember to set the `seed` flag.

Speaking of which, the `seed` executable flag still works, as it takes precedent over the flag set by the tester. 

Also fixed hyperlinks in API2110.md. 