### PR TITLE
LC3Tools v3.1.0

### DIFF
--- a/src/backend/assembler.cpp
+++ b/src/backend/assembler.cpp
@@ -25,26 +25,18 @@ lc3::core::Assembler::assemble(std::istream & buffer)
     bool success = true;
     uint32_t fail_pass = 0;
 
-    std::pair<bool, SymbolTable> symbols;
-    std::pair<bool, std::vector<MemLocation>> machine_code_blob;
-
     logger.printf(PrintType::P_EXTRA, true, "===== begin identifying tokens =====");
-    std::pair<bool, std::vector<Statement>> statements = buildStatements(buffer);
-    success &= statements.first;
+    std::vector<Statement> statements = buildStatements(buffer);
     logger.printf(PrintType::P_EXTRA, true, "===== end identifying tokens =====");
     logger.newline(PrintType::P_EXTRA);
-    if (! success) {
-        fail_pass = 1;
-        goto success_handler; // we don't want to continue assembling the statement if commas are missing
-    }
 
     logger.printf(PrintType::P_EXTRA, true, "===== begin marking PCs =====");
-    setStatementPCField(statements.second);
+    setStatementPCField(statements);
     logger.printf(PrintType::P_EXTRA, true, "===== end marking PCs =====");
     logger.newline(PrintType::P_EXTRA);
 
     logger.printf(PrintType::P_EXTRA, true, "===== begin building symbol table =====");
-    symbols = buildSymbolTable(statements.second);
+    std::pair<bool, SymbolTable> symbols = buildSymbolTable(statements);
     success &= symbols.first;
     logger.printf(PrintType::P_EXTRA, true, "===== end building symbol table =====");
     logger.newline(PrintType::P_EXTRA);
@@ -55,7 +47,7 @@ lc3::core::Assembler::assemble(std::istream & buffer)
     }
 
     logger.printf(PrintType::P_EXTRA, true, "===== begin assembling =====");
-    machine_code_blob = buildMachineCode(statements.second, symbols.second);
+    std::pair<bool, std::vector<MemLocation>> machine_code_blob = buildMachineCode(statements, symbols.second);
     success &= machine_code_blob.first;
     logger.printf(PrintType::P_EXTRA, true, "===== end assembling =====");
     logger.newline(PrintType::P_EXTRA);
@@ -63,7 +55,6 @@ lc3::core::Assembler::assemble(std::istream & buffer)
         fail_pass = 2;
     }
 
-success_handler:
     if(! success) {
         if(fail_pass == 0) {
             logger.printf(PrintType::P_ERROR, true, "assembly failed");
@@ -82,14 +73,13 @@ success_handler:
     return std::make_pair(ret, symbols.second);
 }
 
-std::pair<bool, std::vector<lc3::core::asmbl::Statement>> lc3::core::Assembler::buildStatements(std::istream & buffer)
+std::vector<lc3::core::asmbl::Statement> lc3::core::Assembler::buildStatements(std::istream & buffer)
 {
     using namespace asmbl;
     using namespace lc3::utils;
 
     Tokenizer tokenizer{buffer, enable_liberal_asm};
     std::vector<Statement> statements;
-    bool success = true;
 
     while(! tokenizer.isDone()) {
         std::vector<Token> tokens;
@@ -104,26 +94,20 @@ std::pair<bool, std::vector<lc3::core::asmbl::Statement>> lc3::core::Assembler::
         }
 
         if(! tokenizer.isDone()) {
-            std::pair<bool, Statement> statement = buildStatement(tokens);
-            if (!statement.first) {
-                success = false;
-                break;
-            }
-            statements.push_back(statement.second);
+            statements.push_back(buildStatement(tokens));
         }
     }
 
-    return std::make_pair(success, statements);
+    return statements;
 }
 
-std::pair<bool, lc3::core::asmbl::Statement> lc3::core::Assembler::buildStatement(
+lc3::core::asmbl::Statement lc3::core::Assembler::buildStatement(
     std::vector<lc3::core::asmbl::Token> const & tokens)
 {
     using namespace asmbl;
     using namespace lc3::utils;
 
     Statement ret;
-    bool success = true;
 
     // A lot of special case logic here to identify tokens as labels, instructions, pseudo-ops, etc.
     // Note: This DOES NOT check for valid statements, it just identifies tokens with what they should be
@@ -212,27 +196,7 @@ std::pair<bool, lc3::core::asmbl::Statement> lc3::core::Assembler::buildStatemen
         for(uint32_t i = operand_start_idx; i < tokens.size(); i += 1) {
             if(tokens[i].type == Token::Type::STRING) {
                 if(encoder.isStringValidReg(tokens[i].str)) {
-                    Token regToken = tokens[i];
-                    if (i != tokens.size() - 1) {
-                        // any register not the last operand should still have a comma from the tokenizer
-                        if (regToken.str.back() != ',') {
-                            // signal an error if comma is not present
-                            logger.asmPrintf(PrintType::P_ERROR, ret, "bad statement format (missing/too many commas?)");
-                            success = false;
-                            break;
-                        }
-                        // remove the comma
-                        regToken.str = regToken.str.substr(0, regToken.str.size() - 1);
-                        regToken.len--;
-                    } else {
-                      if (regToken.str.back() == ',') {
-                        // signal an error if comma is present in the last token
-                        logger.asmPrintf(PrintType::P_ERROR, ret, "bad statement format (missing/too many commas?)");
-                        success = false;
-                        break;
-                      }
-                    }
-                    ret.operands.emplace_back(regToken, StatementPiece::Type::REG);
+                    ret.operands.emplace_back(tokens[i], StatementPiece::Type::REG);
                 } else {
                     ret.operands.emplace_back(tokens[i], StatementPiece::Type::STRING);
                 }
@@ -253,7 +217,7 @@ std::pair<bool, lc3::core::asmbl::Statement> lc3::core::Assembler::buildStatemen
     ::operator<<(statement_str, ret);
     logger.printf(PrintType::P_EXTRA, true, "%s", statement_str.str().c_str());
 
-    return std::make_pair(success, ret);
+    return ret;
 }
 
 void lc3::core::Assembler::setStatementPCField(std::vector<lc3::core::asmbl::Statement> & statements)

--- a/src/backend/assembler.cpp
+++ b/src/backend/assembler.cpp
@@ -444,6 +444,13 @@ std::pair<bool, lc3::core::SymbolTable> lc3::core::Assembler::buildSymbolTable(
                         success = false;
                         continue;
                     }
+                    if(!encoder.isValidAlphaNumLabel(statement)) {
+                        logger.asmPrintf(PrintType::P_ERROR, statement, *statement.label,
+                            "label must be alphanumeric with the exception of `_` and `-`");
+                        logger.newline();
+                        success = false;
+                        continue;
+                    }
                 }
 
                 if(encoder.isStringValidReg(statement.label->str)) {

--- a/src/backend/assembler.cpp
+++ b/src/backend/assembler.cpp
@@ -5,6 +5,7 @@
 #include <cassert>
 #include <cctype>
 #include <fstream>
+#include <iostream>
 #include <sstream>
 #include <vector>
 #include <random>
@@ -132,6 +133,9 @@ std::pair<bool, lc3::core::asmbl::Statement> lc3::core::Assembler::buildStatemen
     //       easier to follow the flowchart.
     if(tokens.size() > 0) {
         ret.line = tokens[0].line;
+        ret.line.erase(0, ret.line.find_first_not_of(" \t")); // trim leading whitespace
+        ret.line.erase(ret.line.find_last_not_of(" \t") + 1); // trim trailing whitespace
+
         ret.row = tokens[0].row;
         uint32_t operand_start_idx = 0;
 
@@ -503,8 +507,8 @@ std::pair<bool, std::vector<lc3::core::MemLocation>> lc3::core::Assembler::build
             // we'll now provide the GUI the symbol table to display labels in a separate column
             if (statement.label) {
                 std::string label_str = statement.label->str;
-                int labelInd = statement.line.find_first_of(label_str);
-                line.erase(labelInd, labelInd + label_str.length());
+                int labelInd = line.find(label_str);
+                line.erase(labelInd, label_str.length());
             }
 
             if(encoder.isPseudo(statement)) {
@@ -558,7 +562,7 @@ std::pair<bool, std::vector<lc3::core::MemLocation>> lc3::core::Assembler::build
                 if(candidate) {
                     optional<uint32_t> value = encoder.encodeInstruction(statement, symbols, *candidate);
                     if(value) {
-                        ret.emplace_back(*value, statement.line, false);
+                        ret.emplace_back(*value, line, false);
                         msg << utils::ssprintf("0x%0.4x", *value);
                         valid = true;
                         logger.printf(PrintType::P_EXTRA, true, "  0x%0.4x", *value);

--- a/src/backend/assembler.cpp
+++ b/src/backend/assembler.cpp
@@ -25,18 +25,26 @@ lc3::core::Assembler::assemble(std::istream & buffer)
     bool success = true;
     uint32_t fail_pass = 0;
 
+    std::pair<bool, SymbolTable> symbols;
+    std::pair<bool, std::vector<MemLocation>> machine_code_blob;
+
     logger.printf(PrintType::P_EXTRA, true, "===== begin identifying tokens =====");
-    std::vector<Statement> statements = buildStatements(buffer);
+    std::pair<bool, std::vector<Statement>> statements = buildStatements(buffer);
+    success &= statements.first;
     logger.printf(PrintType::P_EXTRA, true, "===== end identifying tokens =====");
     logger.newline(PrintType::P_EXTRA);
+    if (! success) {
+        fail_pass = 1;
+        goto success_handler; // we don't want to continue assembling the statement if commas are missing
+    }
 
     logger.printf(PrintType::P_EXTRA, true, "===== begin marking PCs =====");
-    setStatementPCField(statements);
+    setStatementPCField(statements.second);
     logger.printf(PrintType::P_EXTRA, true, "===== end marking PCs =====");
     logger.newline(PrintType::P_EXTRA);
 
     logger.printf(PrintType::P_EXTRA, true, "===== begin building symbol table =====");
-    std::pair<bool, SymbolTable> symbols = buildSymbolTable(statements);
+    symbols = buildSymbolTable(statements.second);
     success &= symbols.first;
     logger.printf(PrintType::P_EXTRA, true, "===== end building symbol table =====");
     logger.newline(PrintType::P_EXTRA);
@@ -47,7 +55,7 @@ lc3::core::Assembler::assemble(std::istream & buffer)
     }
 
     logger.printf(PrintType::P_EXTRA, true, "===== begin assembling =====");
-    std::pair<bool, std::vector<MemLocation>> machine_code_blob = buildMachineCode(statements, symbols.second);
+    machine_code_blob = buildMachineCode(statements.second, symbols.second);
     success &= machine_code_blob.first;
     logger.printf(PrintType::P_EXTRA, true, "===== end assembling =====");
     logger.newline(PrintType::P_EXTRA);
@@ -55,6 +63,7 @@ lc3::core::Assembler::assemble(std::istream & buffer)
         fail_pass = 2;
     }
 
+success_handler:
     if(! success) {
         if(fail_pass == 0) {
             logger.printf(PrintType::P_ERROR, true, "assembly failed");
@@ -73,13 +82,14 @@ lc3::core::Assembler::assemble(std::istream & buffer)
     return std::make_pair(ret, symbols.second);
 }
 
-std::vector<lc3::core::asmbl::Statement> lc3::core::Assembler::buildStatements(std::istream & buffer)
+std::pair<bool, std::vector<lc3::core::asmbl::Statement>> lc3::core::Assembler::buildStatements(std::istream & buffer)
 {
     using namespace asmbl;
     using namespace lc3::utils;
 
     Tokenizer tokenizer{buffer, enable_liberal_asm};
     std::vector<Statement> statements;
+    bool success = true;
 
     while(! tokenizer.isDone()) {
         std::vector<Token> tokens;
@@ -94,20 +104,26 @@ std::vector<lc3::core::asmbl::Statement> lc3::core::Assembler::buildStatements(s
         }
 
         if(! tokenizer.isDone()) {
-            statements.push_back(buildStatement(tokens));
+            std::pair<bool, Statement> statement = buildStatement(tokens);
+            if (!statement.first) {
+                success = false;
+                break;
+            }
+            statements.push_back(statement.second);
         }
     }
 
-    return statements;
+    return std::make_pair(success, statements);
 }
 
-lc3::core::asmbl::Statement lc3::core::Assembler::buildStatement(
+std::pair<bool, lc3::core::asmbl::Statement> lc3::core::Assembler::buildStatement(
     std::vector<lc3::core::asmbl::Token> const & tokens)
 {
     using namespace asmbl;
     using namespace lc3::utils;
 
     Statement ret;
+    bool success = true;
 
     // A lot of special case logic here to identify tokens as labels, instructions, pseudo-ops, etc.
     // Note: This DOES NOT check for valid statements, it just identifies tokens with what they should be
@@ -196,7 +212,27 @@ lc3::core::asmbl::Statement lc3::core::Assembler::buildStatement(
         for(uint32_t i = operand_start_idx; i < tokens.size(); i += 1) {
             if(tokens[i].type == Token::Type::STRING) {
                 if(encoder.isStringValidReg(tokens[i].str)) {
-                    ret.operands.emplace_back(tokens[i], StatementPiece::Type::REG);
+                    Token regToken = tokens[i];
+                    if (i != tokens.size() - 1) {
+                        // any register not the last operand should still have a comma from the tokenizer
+                        if (regToken.str.back() != ',') {
+                            // signal an error if comma is not present
+                            logger.asmPrintf(PrintType::P_ERROR, ret, "bad statement format (missing/too many commas?)");
+                            success = false;
+                            break;
+                        }
+                        // remove the comma
+                        regToken.str = regToken.str.substr(0, regToken.str.size() - 1);
+                        regToken.len--;
+                    } else {
+                      if (regToken.str.back() == ',') {
+                        // signal an error if comma is present in the last token
+                        logger.asmPrintf(PrintType::P_ERROR, ret, "bad statement format (missing/too many commas?)");
+                        success = false;
+                        break;
+                      }
+                    }
+                    ret.operands.emplace_back(regToken, StatementPiece::Type::REG);
                 } else {
                     ret.operands.emplace_back(tokens[i], StatementPiece::Type::STRING);
                 }
@@ -210,7 +246,7 @@ lc3::core::asmbl::Statement lc3::core::Assembler::buildStatement(
     ::operator<<(statement_str, ret);
     logger.printf(PrintType::P_EXTRA, true, "%s", statement_str.str().c_str());
 
-    return ret;
+    return std::make_pair(success, ret);
 }
 
 void lc3::core::Assembler::setStatementPCField(std::vector<lc3::core::asmbl::Statement> & statements)

--- a/src/backend/assembler.cpp
+++ b/src/backend/assembler.cpp
@@ -524,6 +524,12 @@ std::pair<bool, std::vector<lc3::core::MemLocation>> lc3::core::Assembler::build
                         msg << utils::ssprintf("0x%0.4x", value);
                     } else if(encoder.isValidPseudoBlock(statement)) {
                         uint32_t size = encoder.getPseudoBlockSize(statement);
+                        // check if size overflows lc3 memory
+                        if (statement.pc + size > 0xFFFF) {
+                            logger.asmPrintf(PrintType::P_ERROR, statement, "block size overflows memory");
+                            logger.newline();
+                            success = false;
+                        }
                         std::random_device rd;
                         std::uniform_int_distribution<> distr(0, 0xFFFF); 
                         // .blkw should technically skip memory locations, but we'll fill with random data to mock that

--- a/src/backend/assembler.h
+++ b/src/backend/assembler.h
@@ -40,8 +40,8 @@ namespace core
 
         asmbl::Encoder encoder;
 
-        std::vector<asmbl::Statement> buildStatements(std::istream & buffer);
-        asmbl::Statement buildStatement(std::vector<asmbl::Token> const & tokens);
+        std::pair<bool, std::vector<asmbl::Statement>> buildStatements(std::istream & buffer);
+        std::pair<bool, asmbl::Statement> buildStatement(std::vector<asmbl::Token> const & tokens);
         void setStatementPCField(std::vector<asmbl::Statement> & statements);
         std::pair<bool, SymbolTable> buildSymbolTable(std::vector<asmbl::Statement> const & statements);
         std::pair<bool, std::vector<MemLocation>> buildMachineCode(std::vector<asmbl::Statement> const & statements,

--- a/src/backend/assembler.h
+++ b/src/backend/assembler.h
@@ -40,8 +40,8 @@ namespace core
 
         asmbl::Encoder encoder;
 
-        std::pair<bool, std::vector<asmbl::Statement>> buildStatements(std::istream & buffer);
-        std::pair<bool, asmbl::Statement> buildStatement(std::vector<asmbl::Token> const & tokens);
+        std::vector<asmbl::Statement> buildStatements(std::istream & buffer);
+        asmbl::Statement buildStatement(std::vector<asmbl::Token> const & tokens);
         void setStatementPCField(std::vector<asmbl::Statement> & statements);
         std::pair<bool, SymbolTable> buildSymbolTable(std::vector<asmbl::Statement> const & statements);
         std::pair<bool, std::vector<MemLocation>> buildMachineCode(std::vector<asmbl::Statement> const & statements,

--- a/src/backend/encoder.cpp
+++ b/src/backend/encoder.cpp
@@ -37,7 +37,10 @@ bool Encoder::isStringValidReg(std::string const & search) const
 {
     std::string lower_search = search;
     std::transform(lower_search.begin(), lower_search.end(), lower_search.begin(), ::tolower);
-    return regs.find(lower_search) != regs.end();
+    // reg string may also contain a comma left by the tokenizer
+    std::string lower_search_comma = search.substr(0, search.size() - 1);
+    std::transform(lower_search_comma.begin(), lower_search_comma.end(), lower_search_comma.begin(), ::tolower);
+    return regs.find(lower_search) != regs.end() || regs.find(lower_search_comma) != regs.end();
 }
 
 bool Encoder::isStringInstructionName(std::string const & name) const

--- a/src/backend/encoder.cpp
+++ b/src/backend/encoder.cpp
@@ -37,10 +37,7 @@ bool Encoder::isStringValidReg(std::string const & search) const
 {
     std::string lower_search = search;
     std::transform(lower_search.begin(), lower_search.end(), lower_search.begin(), ::tolower);
-    // reg string may also contain a comma left by the tokenizer
-    std::string lower_search_comma = search.substr(0, search.size() - 1);
-    std::transform(lower_search_comma.begin(), lower_search_comma.end(), lower_search_comma.begin(), ::tolower);
-    return regs.find(lower_search) != regs.end() || regs.find(lower_search_comma) != regs.end();
+    return regs.find(lower_search) != regs.end();
 }
 
 bool Encoder::isStringInstructionName(std::string const & name) const

--- a/src/backend/encoder.cpp
+++ b/src/backend/encoder.cpp
@@ -37,15 +37,29 @@ bool Encoder::isStringValidReg(std::string const & search) const
 {
     std::string lower_search = search;
     std::transform(lower_search.begin(), lower_search.end(), lower_search.begin(), ::tolower);
-    // reg string may also contain a comma left by the tokenizer
-    std::string lower_search_comma = search.substr(0, search.size() - 1);
-    std::transform(lower_search_comma.begin(), lower_search_comma.end(), lower_search_comma.begin(), ::tolower);
-    return regs.find(lower_search) != regs.end() || regs.find(lower_search_comma) != regs.end();
+    try {
+      // reg string may also contain a comma left by the tokenizer
+      std::string lower_search_comma = search.substr(0, search.size() - 1);
+      std::transform(lower_search_comma.begin(), lower_search_comma.end(), lower_search_comma.begin(), ::tolower);
+      return regs.find(lower_search) != regs.end() || regs.find(lower_search_comma) != regs.end();
+    } catch (std::exception & e) { // defensive catch in case anything with search goes wrong
+        return false;
+    }
 }
 
 bool Encoder::isStringInstructionName(std::string const & name) const
 {
     return instructions_by_name.count(utils::toLower(name));
+}
+
+bool Encoder::isValidAlphaNumLabel(Statement const & statement) const
+{
+    for(char c : statement.label->str) {
+        if(! std::isalnum(c) && c != '_' && c != '-') {
+            return false;
+        }
+    }
+    return true;
 }
 
 bool Encoder::isValidPseudoOrig(Statement const & statement, bool log_enable) const

--- a/src/backend/encoder.h
+++ b/src/backend/encoder.h
@@ -26,6 +26,7 @@ namespace asmbl
         bool isStringInstructionName(std::string const & name) const;
         bool isPseudo(Statement const & statement) const;
         bool isInst(Statement const & statement) const;
+        bool isValidAlphaNumLabel(Statement const & statement) const;
         bool isValidPseudoOrig(Statement const & statement, bool log_enable = false) const;
         bool isValidPseudoFill(Statement const & statement, bool log_enable = false) const;
         bool isValidPseudoFill(Statement const & statement, SymbolTable const & symbols,

--- a/src/backend/tokenizer.cpp
+++ b/src/backend/tokenizer.cpp
@@ -103,6 +103,7 @@ lc3::core::asmbl::Tokenizer & lc3::core::asmbl::Tokenizer::operator>>(Token & to
     // If we've made it here, we have a valid token. First find the length.
     uint32_t len = 0;
     bool found_string = false;
+    bool found_comment = false;
     if(line[col] == '"' && (col == 0 || line[col - 1] != '\\')) {
         // If token begins with an non-escaped quotation mark, the length goes on until the matching non-escaped
         // quotation mark (or EOL if non exists).
@@ -113,6 +114,11 @@ lc3::core::asmbl::Tokenizer & lc3::core::asmbl::Tokenizer::operator>>(Token & to
         found_string = true;
     } else {
         while(col + len < line.size() && delims.find(line[col + len]) == std::string::npos) {
+        if (line[col + len] == ';' && !found_string) {
+            // if we find a comment after an instruction without any whitespace, stop the token
+            found_comment = true;
+            break;
+        }
             len += 1;
         }
     }
@@ -133,6 +139,7 @@ lc3::core::asmbl::Tokenizer & lc3::core::asmbl::Tokenizer::operator>>(Token & to
     token.line = line;
 
     col += len + 1;
+    if (found_comment) col--; // don't skip the semicolon in the above case
 
     return *this;
 }

--- a/src/backend/tokenizer.cpp
+++ b/src/backend/tokenizer.cpp
@@ -199,6 +199,8 @@ bool lc3::core::asmbl::Tokenizer::convertStringToNum(std::string const & str, in
     } catch(std::out_of_range const & e) {
         (void) e;
         return false;
+    } catch(...) { // somehow the above exception is not caught when building into a node module on macos
+        return false;
     }
 }
 

--- a/src/backend/tokenizer.cpp
+++ b/src/backend/tokenizer.cpp
@@ -53,7 +53,7 @@ lc3::core::asmbl::Tokenizer & lc3::core::asmbl::Tokenizer::operator>>(Token & to
         }
 
         col = 0;
-        row += 1;
+        row++;
 
         // Mark as done if we've reached EOF.
         if(getline(buffer, line).eof()) {
@@ -89,7 +89,7 @@ lc3::core::asmbl::Tokenizer & lc3::core::asmbl::Tokenizer::operator>>(Token & to
     // Ignore delimeters entirely.
     std::string delims = ": \t";
     while(col < line.size() && delims.find(line[col]) != std::string::npos) {
-        col += 1;
+        col++;
     }
 
     // If there's nothing left on this line, get a new line (but first return EOL).
@@ -104,24 +104,31 @@ lc3::core::asmbl::Tokenizer & lc3::core::asmbl::Tokenizer::operator>>(Token & to
     uint32_t len = 0;
     bool found_string = false;
     bool found_comment = false;
+    bool argument_delim = false;
     if(line[col] == '"' && (col == 0 || line[col - 1] != '\\')) {
         // If token begins with an non-escaped quotation mark, the length goes on until the matching non-escaped
         // quotation mark (or EOL if non exists).
-        col += 1;    // Consume first non-escaped quotation mark.
+        col++;    // Consume first non-escaped quotation mark.
         while(col + len < line.size() && ! (line[col + len] == '"' && line[col + len - 1] != '\\')) {
-            len += 1;
+            len++;
         }
         found_string = true;
     } else {
         while(col + len < line.size() && delims.find(line[col + len]) == std::string::npos) {
-        if (line[col + len] == ';' && !found_string) {
+        if (line[col + len] == ';') {
             // if we find a comment after an instruction without any whitespace, stop the token
             found_comment = true;
             break;
+        } else if (line[col + len] == ',') {
+            // also break if we find a comma, but still consume it with the current token
+            argument_delim = true;
+            len++;
+            break;
         }
-            len += 1;
+            len++;
         }
     }
+
 
     // Attempt to convert token into numeric value. If possible, mark as NUM. Otherwise, mark as STRING.
     int32_t token_num_val = 0;
@@ -139,7 +146,10 @@ lc3::core::asmbl::Tokenizer & lc3::core::asmbl::Tokenizer::operator>>(Token & to
     token.line = line;
 
     col += len + 1;
-    if (found_comment) col--; // don't skip the semicolon in the above case
+
+    // don't skip the semicolon in the above case (so we can catch the comment in the next `>>` call)...
+    // nor will we skip any character after the comma in case there isn't a space after it
+    if (found_comment || argument_delim) col--;
 
     return *this;
 }

--- a/src/backend/tokenizer.cpp
+++ b/src/backend/tokenizer.cpp
@@ -87,7 +87,7 @@ lc3::core::asmbl::Tokenizer & lc3::core::asmbl::Tokenizer::operator>>(Token & to
     }
 
     // Ignore delimeters entirely.
-    std::string delims = ",: \t";
+    std::string delims = ": \t";
     while(col < line.size() && delims.find(line[col]) != std::string::npos) {
         col += 1;
     }

--- a/src/backend/tokenizer.cpp
+++ b/src/backend/tokenizer.cpp
@@ -87,7 +87,7 @@ lc3::core::asmbl::Tokenizer & lc3::core::asmbl::Tokenizer::operator>>(Token & to
     }
 
     // Ignore delimeters entirely.
-    std::string delims = ": \t";
+    std::string delims = ",: \t";
     while(col < line.size() && delims.find(line[col]) != std::string::npos) {
         col += 1;
     }

--- a/src/gui/local_modules/lc3interface/package.json
+++ b/src/gui/local_modules/lc3interface/package.json
@@ -1,6 +1,6 @@
 {
     "name": "lc3interface",
-    "version": "2.0.2",
+    "version": "3.1.0",
     "description": "LC-3 Backend",
     "gypfile": true,
     "main": "./build/Release/lc3interface",

--- a/src/gui/package.json
+++ b/src/gui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "LC3Tools",
-  "version": "3.0.2",
+  "version": "3.1.0",
   "author": "gt-cs2110",
   "description": "LC3Tools frontend",
   "license": "MIT",

--- a/src/gui/src/renderer/App.vue
+++ b/src/gui/src/renderer/App.vue
@@ -121,7 +121,9 @@
                 May result in inconsistency with the grader.
               </p>
               <v-layout row>
-                <v-flex grow><h4>Issues? Post on CS 2110 Ed/Piazza!</h4></v-flex>
+                <v-flex grow
+                  ><h4>Issues? Post on CS 2110 Ed/Piazza!</h4></v-flex
+                >
               </v-layout>
             </v-container>
           </v-card>
@@ -238,9 +240,9 @@ export default {
         ignore_privilege: false,
         liberal_asm: false,
         ignore_update: false,
-        run_until_halt: false,
+        run_until_halt: true,
         clear_out_on_reload: true,
-		autocomplete: "full"
+        autocomplete: "full"
       }
     };
   },

--- a/src/gui/src/renderer/components/editor/Editor.vue
+++ b/src/gui/src/renderer/components/editor/Editor.vue
@@ -160,7 +160,7 @@ export default {
         );
         this.editor.original_content = this.editor.current_content;
       }
-      this.build()
+      this.build();
     },
     autosaveFile() {
       if (
@@ -223,34 +223,36 @@ export default {
         }
       }
 
-			const temp_console_string = lc3.GetAndClearOutput();
-			this.console_str = "";
-			setTimeout(() => {
-				this.console_str = temp_console_string;
-			}, 200);
-			if (success) {
-				this.$store.commit("touchActiveFileBuildTime");
-			}
-		},
-		editorInit(editor) {
-			require("./lc3");
-			require("brace/mode/html");
-			require("brace/mode/javascript");
-			require("brace/mode/less");
-			require("brace/theme/textmate");
-			require("brace/theme/twilight");
-			require("brace/ext/searchbox");
-			require("brace/keybinding/vim");
-			require("brace/ext/language_tools"); // for more config: const langTools = ace.acequire("ace/ext/language_tools");
-			editor.setShowPrintMargin(false);
-			editor.setOptions({
-				fontSize: "1.25em",
-				scrollPastEnd: 0.7,
-			});
-			editor.setOptions({
-				enableBasicAutocompletion: [CreateLc3CompletionProvider(() => this.autocompleteMode)],
-				enableLiveAutocompletion: true
-			});
+      const temp_console_string = lc3.GetAndClearOutput();
+      this.console_str = "";
+      setTimeout(() => {
+        this.console_str = temp_console_string;
+      }, 200);
+      if (success) {
+        this.$store.commit("touchActiveFileBuildTime");
+      }
+    },
+    editorInit(editor) {
+      require("./lc3");
+      require("brace/mode/html");
+      require("brace/mode/javascript");
+      require("brace/mode/less");
+      require("brace/theme/textmate");
+      require("brace/theme/twilight");
+      require("brace/ext/searchbox");
+      require("brace/keybinding/vim");
+      require("brace/ext/language_tools"); // for more config: const langTools = ace.acequire("ace/ext/language_tools");
+      editor.setShowPrintMargin(false);
+      editor.setOptions({
+        fontSize: "1.25em",
+        scrollPastEnd: 0.7
+      });
+      editor.setOptions({
+        enableBasicAutocompletion: [
+          CreateLc3CompletionProvider(() => this.autocompleteMode)
+        ],
+        enableLiveAutocompletion: true
+      });
       editor.commands.addCommand({
         name: "save",
         bindKey: { win: "Ctrl-S", mac: "Cmd-S" },
@@ -318,20 +320,19 @@ export default {
 };
 </script>
 
-
 <style>
 .ace_editor.ace_autocomplete.ace_twilight {
-	background-color: red;
+  background-color: red;
 }
 
 .ace_editor.ace_autocomplete .ace_marker-layer .ace_active-line {
-	background-color: blue;
+  background-color: blue;
 }
 .ace_twilight {
-	 background-color: red !important;
+  background-color: red !important;
 }
 .ace_twilight .ace_completion-highlight {
-	color: orange !important;
+  color: orange !important;
 }
 </style>
 

--- a/src/gui/src/renderer/components/editor/completions.js
+++ b/src/gui/src/renderer/components/editor/completions.js
@@ -9,7 +9,6 @@
  * 'full': `basic` functionality plus best-effort label suggestion (more document processing on keystroke required)
  *
  * Issues/Areas for improvement:
- * > with autocomplete='full', string contents will be suggested as labels (really they should be ignored)
  * > do 'full' autocompletion document parsing more efficiently? (not sure how bad of an issue this currently is?)
  *
  */
@@ -40,93 +39,157 @@ const keywordSet = new Set(
   )
 );
 
+const instrCompletions = [
+  ...instrs.map(name => ({
+    value: name,
+    score: 10,
+    meta: "instruction"
+  }))
+];
+
+const instrAliasCompletions = [
+  ...instrAliases.map(name => ({
+    value: name,
+    score: 10,
+    meta: "alias"
+  }))
+];
+
+const pseudoOpCompletions = [
+  ...pseudoOps.map(name => ({
+    value: name,
+    score: 10,
+    meta: "pseudo-op"
+  }))
+];
+
+const regCompletions = [
+  ...regNames.map(name => ({
+    value: name,
+    score: 11,
+    meta: "register"
+  }))
+];
+
 function generateCompletions(mode, doc, pos, prefix) {
-    if (mode === "none") {
-      return [];
-    }
+  if (mode === "none") {
+    return [];
+  }
 
-    // typing a number
-    if (/^\d/.test(prefix)) {
-      return [];
-    }
+  // typing a number
+  if (/^\d/.test(prefix)) {
+    return [];
+  }
 
-    // in a comment
-    const currentLine = doc.getLine(pos.row);
-    const currentLineUpToCursor = currentLine.substring(0, pos.column - 1);
-    if (currentLineUpToCursor.includes(";")) {
-      return [];
-    }
+  // in a comment
+  const currentLine = doc.getLine(pos.row);
+  const currentLineUpToCursor = currentLine.substring(0, pos.column);
+  if (currentLineUpToCursor.includes(";")) {
+    return [];
+  }
 
-    let labelsReferenced = new Set();
+  let labelsReferenced = new Set();
 
-    if (mode == "full") {
-      const documentLines = doc.getAllLines();
-      for (const line of documentLines) {
-        const nonCommentLine = line.includes(";")
-          ? line.substring(0, line.indexOf(";"))
-          : line;
+  if (mode == "full") {
+    const documentLines = doc.getAllLines();
+    for (const line of documentLines) {
+      const nonCommentLine = line.includes(";")
+        ? line.substring(0, line.indexOf(";"))
+        : line;
 
-        const matches = nonCommentLine.match(/\w[\d\w]*/g);
-        if (matches) {
-          for (const match of matches) {
-            if (match === prefix) {
-              continue;
-            } // do not complete with what is currently being typed!
+      // remove strings (items between quotes) from potential matches
+      const nonStringLine = nonCommentLine.replace(/["'].*?["']/g, "");
 
-            const lowerMatch = match.toLowerCase();
-            if (/^x[a-f\d]+$/.test(lowerMatch)) {
-              continue;
-            } // hex, not label
-            if (/^\d+$/.test(lowerMatch)) {
-              continue;
-            } // number, not label
-            if (/^brn?z?p?$/.test(lowerMatch)) {
-              continue;
-            } // BR, not label
-            if (keywordSet.has(lowerMatch)) {
-              continue;
-            } // existing keyword, not label
+      const matches = nonStringLine.match(/\w[\d\w]*/g);
+      if (matches) {
+        for (const match of matches) {
+          if (match === prefix) {
+            continue;
+          } // do not complete with what is currently being typed!
 
-            labelsReferenced.add(match);
+          const lowerMatch = match.toLowerCase();
+
+          if (
+            /^x[a-f\d]+$/.test(lowerMatch) || // hex
+            /^\d+$/.test(lowerMatch) || // number
+            /^brn?z?p?$/.test(lowerMatch) || // BR
+            keywordSet.has(lowerMatch) // existing keyword
+          ) {
+            // none of the above are labels
+            continue;
           }
+
+          labelsReferenced.add(match);
         }
       }
     }
+  }
 
-    const completions = [
-      ...regNames.map(name => ({
-        value: name,
-        score: 11,
-        meta: "register"
-      })),
-      ...instrs.map(name => ({
-        value: name,
-        score: 10,
-        meta: "instruction"
-      })),
-      ...instrAliases.map(name => ({
-        value: name,
-        score: 10,
-        meta: "alias"
-      })),
-      ...pseudoOps.map(name => ({
-        value: name,
-        score: 10,
-        meta: "pseudo-op"
-      })),
-      ...[...labelsReferenced].map(name => ({
-        value: name,
-        score: 5,
-        meta: "label"
-      }))
+  const labelsCompletions = [...labelsReferenced].map(name => ({
+    value: name,
+    score: 5,
+    meta: "label"
+  }));
+
+  const currTokens = currentLineUpToCursor.match(/\b\w+\b|\./g);
+
+  console.log("currTokens", currTokens);
+
+  // if we are at the beginning of the line
+  if (!currTokens) {
+    const tokensAfter = currentLine
+      .substring(pos.column - 1)
+      .match(/^\b\w+\b/g);
+    return [
+      // if there are no tokens after the cursor, should suggest instructions
+      ...(tokensAfter ? [...instrCompletions, ...instrAliasCompletions] : []),
+      ...labelsCompletions
     ];
+  }
 
-	return completions;
+  let firstToken = currTokens[0].toLowerCase();
+
+  // check if first token is label
+  if (!keywordSet.has(firstToken) && firstToken !== ".") {
+    // if label is the only token, suggest instructions (labels shouldn't be attached to pseudo-ops)
+    if (currTokens.length === 1) {
+      return [...instrCompletions, ...instrAliasCompletions];
+    }
+    // otherwise, reassign firstToken to the "instruction"
+    currTokens.shift();
+    firstToken = currTokens[0].toLowerCase();
+  }
+
+  // if first token is a period, student is trying to write a pseudo-ops
+  if (firstToken === ".") {
+    return pseudoOpCompletions;
+  }
+
+  // if first token is a BR instruction, suggest labels
+  if (/^brn?z?p?$/.test(firstToken)) {
+    return labelsCompletions;
+  }
+
+  // if instruction, suggest registers
+  if (instrs.includes(firstToken.toUpperCase())) {
+    return [
+      ...regCompletions,
+      // suggest labels as well for instructions with PC-relative addressing
+      ...(["JSR", "LD", "LDI", "ST", "STI", "LEA"].includes(
+        firstToken.toUpperCase()
+      )
+        ? labelsCompletions
+        : [])
+    ];
+  }
+
+  // otherwise, no suggestions
+  return [];
 }
 
 // modeGetter => returns current autocomplete setting
-export const CreateLc3CompletionProvider = (modeGetter) => ({
+export const CreateLc3CompletionProvider = modeGetter => ({
   getCompletions: (_editor, session, pos, prefix, callback) => {
-	  callback(null, generateCompletions(modeGetter(), session.doc, pos, prefix));
+    callback(null, generateCompletions(modeGetter(), session.doc, pos, prefix));
   }
 });

--- a/src/gui/src/renderer/components/simulator/Simulator.vue
+++ b/src/gui/src/renderer/components/simulator/Simulator.vue
@@ -357,13 +357,13 @@
                     }}</span>
                   </v-tooltip>
                   <v-tooltip top>
-                    <v-btn icon @click="jumpToPrevPartMemView" slot="activator"
+                    <v-btn icon @click="() => {jumpToPartMemView(-5)}" slot="activator"
                       ><v-icon>arrow_back</v-icon></v-btn
                     >
                     <span>{{ toHex((mem_view.start - 5) & 0xffff) }}</span>
                   </v-tooltip>
                   <v-tooltip top>
-                    <v-btn icon @click="jumpToNextPartMemView" slot="activator"
+                    <v-btn icon @click="() => {jumpToPartMemView(5)}" slot="activator"
                       ><v-icon>arrow_forward</v-icon></v-btn
                     >
                     <span>{{ toHex((mem_view.start + 5) & 0xffff) }}</span>
@@ -464,7 +464,7 @@ export default {
       },
       loadedSnackBar: false,
       jmp_to_loc_field: "",
-      scrollTicking: false
+      memScrollOffset: 0
     };
   },
   components: {},
@@ -508,16 +508,11 @@ export default {
   methods: {
     handleMemoryScroll(event) {
       event.preventDefault();
-      const direction = event.deltaY > 0; // true if scrolling down
-      window.requestAnimationFrame(() => {
-        if (direction) {
-          this.jumpToNextPartMemView();
-        } else {
-          this.jumpToPrevPartMemView();
-        }
-        this.scrollTicking = false;
-      });
-      this.scrollTicking = true;
+      this.memScrollOffset += event.deltaY;
+      if (Math.abs(this.memScrollOffset) > 20) {
+        this.jumpToPartMemView(Math.floor(this.memScrollOffset / 20));
+        this.memScrollOffset = 0;
+      }
     },
     refreshMemoryPanel() {
       this.mem_view.data = [];
@@ -810,16 +805,12 @@ export default {
       let new_start = this.mem_view.start - this.mem_view.data.length;
       this.jumpToMemView(new_start);
     },
-    jumpToPrevPartMemView() {
-      let new_start = this.mem_view.start - 5;
-      this.jumpToMemView(new_start);
-    },
     jumpToNextMemView() {
       let new_start = this.mem_view.start + this.mem_view.data.length;
       this.jumpToMemView(new_start);
     },
-    jumpToNextPartMemView() {
-      let new_start = this.mem_view.start + 5;
+    jumpToPartMemView(netLines) {
+      let new_start = this.mem_view.start + netLines;
       this.jumpToMemView(new_start);
     },
     jumpToPC(jump_if_in_view) {

--- a/src/gui/src/renderer/components/simulator/Simulator.vue
+++ b/src/gui/src/renderer/components/simulator/Simulator.vue
@@ -463,7 +463,8 @@ export default {
         }
       },
       loadedSnackBar: false,
-      jmp_to_loc_field: ""
+      jmp_to_loc_field: "",
+      scrollTicking: false
     };
   },
   components: {},
@@ -480,12 +481,14 @@ export default {
   },
   mounted() {
     this.refreshMemoryPanel();
+    this.$refs.memView.addEventListener("wheel", this.handleMemoryScroll);
   },
   created() {
     window.addEventListener("resize", this.refreshMemoryPanel);
   },
   destroyed() {
     window.removeEventListener("resize", this.refreshMemoryPanel);
+    this.$refs.memView.addEventListener("wheel", this.handleMemoryScroll);
   },
   activated() {
     let asm_file_name = this.$store.getters.activeFilePath;
@@ -503,6 +506,19 @@ export default {
     }
   },
   methods: {
+    handleMemoryScroll(event) {
+      event.preventDefault();
+      const direction = event.deltaY > 0; // true if scrolling down
+      window.requestAnimationFrame(() => {
+        if (direction) {
+          this.jumpToNextPartMemView();
+        } else {
+          this.jumpToPrevPartMemView();
+        }
+        this.scrollTicking = false;
+      });
+      this.scrollTicking = true;
+    },
     refreshMemoryPanel() {
       this.mem_view.data = [];
       for (

--- a/src/gui/src/renderer/components/simulator/Simulator.vue
+++ b/src/gui/src/renderer/components/simulator/Simulator.vue
@@ -357,13 +357,27 @@
                     }}</span>
                   </v-tooltip>
                   <v-tooltip top>
-                    <v-btn icon @click="() => {jumpToPartMemView(-5)}" slot="activator"
+                    <v-btn
+                      icon
+                      @click="
+                        () => {
+                          jumpToPartMemView(-5);
+                        }
+                      "
+                      slot="activator"
                       ><v-icon>arrow_back</v-icon></v-btn
                     >
                     <span>{{ toHex((mem_view.start - 5) & 0xffff) }}</span>
                   </v-tooltip>
                   <v-tooltip top>
-                    <v-btn icon @click="() => {jumpToPartMemView(5)}" slot="activator"
+                    <v-btn
+                      icon
+                      @click="
+                        () => {
+                          jumpToPartMemView(5);
+                        }
+                      "
+                      slot="activator"
                       ><v-icon>arrow_forward</v-icon></v-btn
                     >
                     <span>{{ toHex((mem_view.start + 5) & 0xffff) }}</span>

--- a/src/gui/src/renderer/store/modules/Settings.js
+++ b/src/gui/src/renderer/store/modules/Settings.js
@@ -5,9 +5,9 @@ const state = {
   ignore_privilege: false,
   liberal_asm: false,
   ignore_update: false,
-  run_until_halt: false,
+  run_until_halt: true,
   clear_out_on_reload: true,
-	autocomplete: 'full' // 'none' | 'basic' | 'full'
+  autocomplete: "full" // 'none' | 'basic' | 'full'
 };
 
 const mutations = {
@@ -37,23 +37,23 @@ const mutations = {
   },
   setAutocomplete(state, setting) {
     state.autocomplete = setting;
-  },
+  }
 };
 
 const getters = {
-  theme: (state) => state.theme,
-  number_type: (state) => state.number_type,
-  editor_binding: (state) => state.editor_binding,
-  ignore_privilege: (state) => state.ignore_privilege,
-  liberal_asm: (state) => state.liberal_asm,
-  ignore_update: (state) => state.ignore_update,
-  run_until_halt: (state) => state.run_until_halt,
-  clear_out_on_reload: (state) => state.clear_out_on_reload,
-  autocomplete: (state) => state.autocomplete,
+  theme: state => state.theme,
+  number_type: state => state.number_type,
+  editor_binding: state => state.editor_binding,
+  ignore_privilege: state => state.ignore_privilege,
+  liberal_asm: state => state.liberal_asm,
+  ignore_update: state => state.ignore_update,
+  run_until_halt: state => state.run_until_halt,
+  clear_out_on_reload: state => state.clear_out_on_reload,
+  autocomplete: state => state.autocomplete
 };
 
 export default {
   state,
   mutations,
-  getters,
+  getters
 };


### PR DESCRIPTION
Features:
- Introduces memview scrolling in the simulator 🙌
- Improves Toby's autocomplete PR
- Change default for "stop execution on reaching HALT" for the students' convenience

Additonally, fixes the following (practically all of the whitescreen/crashing bugs while preserving comma enforcement):

- Instructions will not assemble unless you have spaces after your commas between each argument  
	- `ADD R0,R0,0` does not assemble, but `ADD R0, R0, 0` does

- Instructions will not assemble if a semicolon is put right after an instruction 
	- `ADD R0, R0, 0;test` does not assemble, but `ADD R0, R0, 0 ;test` does

- `AND` / `ADD` Instructions that have a single semicolon after the last register argument will break the assembler

- A single value on its own line will crash lc3tools on all machines
	- Turns out this was a byproduct with my previous label extraction implementation (sorry 😓)

- `.fill xFFFFFFFFFFFFFFF` or any value beyond the 32-bit signed integer limit will crash lc3tools
	- Weird exception catching bug specifically on macos that I can't figure out, so am using `catch(...)`

- Labels must now be alphanumeric with exception to `-` and `_` (they still can't start with a number)
	- Things like `ADD, ADD R0, R0, R0` now no longer works, as `ADD,` would previously have been interpreted as a label

- Instructions with inline labels will now display properly

- Prevent assembling `.blkw` with a high enough argument such that it overflow the lc3 memory address space